### PR TITLE
Fix editor freeze when loading an invalid project

### DIFF
--- a/Xenity_Engine/Source/engine/asset_management/project_manager.cpp
+++ b/Xenity_Engine/Source/engine/asset_management/project_manager.cpp
@@ -568,12 +568,14 @@ ProjectLoadingErrors ProjectManager::LoadProject(const std::string& projectPathT
 		if (!s_fileDataBase.GetBitFile().Open("data.xenb"))
 		{
 			Debug::PrintError("[ProjectManager::LoadProject] Failed to open the data file", true);
+			s_projectState = ProjectState::NotLoaded;
 			return ProjectLoadingErrors::FailedToOpenDataFile;
 		}
 	}
 	else
 	{
 		Debug::PrintError("[ProjectManager::LoadProject] Failed to open the data base file", true);
+		s_projectState = ProjectState::NotLoaded;
 		return ProjectLoadingErrors::FailedToOpenDataBaseFile;
 	}
 #endif
@@ -583,6 +585,7 @@ ProjectLoadingErrors ProjectManager::LoadProject(const std::string& projectPathT
 #if defined(EDITOR)
 	if (!std::filesystem::exists(s_assetFolderPath))
 	{
+		s_projectState = ProjectState::NotLoaded;
 		return ProjectLoadingErrors::NoAssetFolder;
 	}
 	FileSystem::CreateFolder(s_projectFolderPath + "/temp/");
@@ -620,6 +623,7 @@ ProjectLoadingErrors ProjectManager::LoadProject(const std::string& projectPathT
 #if !defined(EDITOR)
 	if (!ProjectManager::GetStartScene())
 	{
+		s_projectState = ProjectState::NotLoaded;
 		return ProjectLoadingErrors::NoStartupScene;
 	}
 #endif


### PR DESCRIPTION
Previously, if you load an invalid project (one without asset folder), the editor will be greyed out. This will change the project state to Notloaded if an error is gotten during loading, which will allow the editor to continue operating.

I also did the same for when the data file, database file or default scene is missing, although I couldn't reproduce the issue in the older version; if they are missing, it just leads into a crash anyway.