### PR TITLE
Skybox cubemap up angle fix

### DIFF
--- a/Xenity_Engine/Source/engine/graphics/graphics.cpp
+++ b/Xenity_Engine/Source/engine/graphics/graphics.cpp
@@ -680,7 +680,7 @@ void Graphics::DrawSkybox(const Vector3& cameraPosition)
 		Graphics::DrawSubMesh(Vector3(0, -5, 0) + cameraPosition, q0, scale, *skyPlane->m_subMeshes[0], *AssetManager::unlitMaterial, renderSettings);
 
 		AssetManager::unlitMaterial->m_texture = s_settings.skybox->up;
-		static const Quaternion q1 = Quaternion::Euler(180, 180, 0);
+		static const Quaternion q1 = Quaternion::Euler(180, 90, 0);
 		Graphics::DrawSubMesh(Vector3(0, 5, 0) + cameraPosition, q1, scale, *skyPlane->m_subMeshes[0], *AssetManager::unlitMaterial, renderSettings);
 
 		AssetManager::unlitMaterial->m_texture = s_settings.skybox->front;


### PR DESCRIPTION
Fix the rotation of the cubemap up angle so it lines up with the other elements.
- Only tested on a ps vita

**Before:**
<img width="700" height="500" alt="Screenshot 2026-08-08 175428" src="https://github.com/user-attachments/assets/a3c792ff-0254-45de-9d72-874c8b43a2bd" />

**After:**
<img width="700" height="500" alt="Screenshot 2026-08-08 175328" src="https://github.com/user-attachments/assets/c674c72a-e148-4d66-83c1-a9cb6267496a" />
